### PR TITLE
Fix: update keymap selector to work correctly on linux

### DIFF
--- a/keymaps/terminal.cson
+++ b/keymaps/terminal.cson
@@ -43,7 +43,7 @@
   "cmd-g": "terminal:find-next"
   "cmd-shift-g": "terminal:find-previous"
 
-".platform-win32 atom-workspace, .platform-linux .atom-workspace":
+".platform-win32 atom-workspace, .platform-linux atom-workspace":
   # Activate the last active terminal, creating a new one if needed.
   "ctrl-`": "terminal:focus"
   # Explicitly create a new terminal in the default location.


### PR DESCRIPTION
I was looking at the keybindings but was struggling to get anything to work even though the commands worked just fine.

Looks like there is a mistaken `.` in front of the `atom-workspace` selector. Removing it seems to have resolved the problem.

Before: <kbd>Ctrl + \` </kbd> did nothing
After: <kbd>Ctrl + \` </kbd> focuses terminal