### PR TITLE
Fixes terminal:set-selection-as-find-pattern keybind

### DIFF
--- a/keymaps/terminal.cson
+++ b/keymaps/terminal.cson
@@ -73,7 +73,7 @@
   "ctrl-f": "terminal:find"
   "f3": "terminal:find-next"
   "shift-f3": "terminal:find-previous"
-  "ctrl-e": "terminal:use-selection-as-find-pattern"
+  "ctrl-e": "terminal:set-selection-as-find-pattern"
   # Ordinarily we'd bind an unfocus command to Esc — but Esc in particular
   # seems to stubbornly be claimed by Xterm, even if modifier keys are present!
   "ctrl-`": "terminal:unfocus"


### PR DESCRIPTION
Command is "terminal:**set**-selecton-as-find-pattern rather than "terminal:**use**-selection-as-find-pattern": https://github.com/pulsar-edit/terminal/blob/135d2b62a6838e63e413794f75f63ba51f67f121/src/terminal.ts#L144

This is correct in the `.darwin` scope. Technically solves *part* of issue not previously fully identified by #9 (read comments for info)