### PR TITLE
Fix context menu commands

### DIFF
--- a/menus/terminal.json
+++ b/menus/terminal.json
@@ -49,31 +49,31 @@
               },
               {
                 "label": "Split Up",
-                "command": "terminal:open-up-context-menu"
+                "command": "terminal:open-split-up-context-menu"
               },
               {
                 "label": "Split Down",
-                "command": "terminal:open-down-context-menu"
+                "command": "terminal:open-split-down-context-menu"
               },
               {
                 "label": "Split Left",
-                "command": "terminal:open-left-context-menu"
+                "command": "terminal:open-split-left-context-menu"
               },
               {
                 "label": "Split Right",
-                "command": "terminal:open-right-context-menu"
+                "command": "terminal:open-split-right-context-menu"
               },
               {
                 "label": "Bottom Dock",
-                "command": "terminal:open-bottom-dock-context-menu"
+                "command": "terminal:open-split-bottom-dock-context-menu"
               },
               {
                 "label": "Left Dock",
-                "command": "terminal:open-left-dock-context-menu"
+                "command": "terminal:open-split-left-dock-context-menu"
               },
               {
                 "label": "Right Dock",
-                "command": "terminal:open-right-dock-context-menu"
+                "command": "terminal:open-split-right-dock-context-menu"
               }
             ]
           },


### PR DESCRIPTION
Only the `Open new in... > Center` context menu item was working even though there were no issues with the commands themselves.

The `menu > terminal.json` had commands against each of the `split` entries that did not match the commands actually registered (omitted the `split` in the string).

This PR just fixes these commands to the actual registered command names.