### PR TITLE
Fix terminal:open-*-dock commands ignoring their target location

### DIFF
--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -575,12 +575,16 @@ export default class Terminal {
     switch (centerOrDock) {
       case atom.workspace.getBottomDock():
         location = 'bottom';
+        break;
       case atom.workspace.getLeftDock():
         location = 'left';
+        break;
       case atom.workspace.getRightDock():
         location = 'right';
+        break;
       case atom.workspace.getCenter():
         location = 'center';
+        break;
       default:
         location = undefined;
     }


### PR DESCRIPTION
## Summary

`Terminal.openInCenterOrDock` (`src/terminal.ts`) builds a `location` value with a `switch`, but none of the cases have `break` statements. Every case falls through to `default`, which resets `location` back to `undefined`. `options.location` is therefore never set, and `open()` falls back to `getActiveWorkspaceLocation()` (the active pane container) — so the terminal opens in the center instead of the requested dock.

This fixes the `terminal:open-bottom-dock`, `terminal:open-left-dock`, `terminal:open-right-dock` and `terminal:open-center` commands. The `*-context-menu` variants were already fine because they go through `addDefaultPosition`, which is consistent with what #27 reports.

Fixes #27.

## Changes

- Add the missing `break` statements in `openInCenterOrDock` (`src/terminal.ts`).

`lib/` is intentionally left untouched: the build output appears to be committed only at release time (`prepublishOnly`), and recent source-only commits don't include it.

## How to test

1. Close the bottom dock.
2. Run `terminal:open-bottom-dock` from the command palette.
3. The terminal now opens in the bottom dock (previously it opened in the center, with the console logging `{location: 'center'}`).
4. Repeat with `terminal:open-left-dock` / `terminal:open-right-dock`.

## Disclosure

This change was generated with AI assistance (Claude Opus 4.8 Max) and reviewed before submitting. I fully understand if you'd prefer not to accept an AI-assisted contribution — feel free to close it; the root cause is documented above and in #27 regardless.